### PR TITLE
Dms

### DIFF
--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -46,16 +46,14 @@ chat.get('/dms', async (req, res) => {
 });
 
 chat.get('/existingDms', async (req, res) => {
-  console.log(req);
-  // only need user id
   const { senderId } = req.query;
   const senderNum: number = Number(senderId);
-  // find all users that currently have dms with user
-  // select name, id, and most recent message
-  // figure out how to only select the most recent msg from current chats
-  // maybe try to first get only the ids - then a second that only grabs the first from those ids
+  // this query grabs the most recent sent and received msg from every convo user is a part of
+  // the most recent msg comes first
   const existingDms = await Message.findMany({
     where: { OR: [{ senderId: senderNum }, { recipientId: senderNum }] },
+    orderBy: [{ id: 'desc' }],
+    distinct: ['senderId', 'recipientId'],
     select: {
       senderId: true,
       recipientId: true,

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -45,12 +45,12 @@ chat.get('/dms', async (req, res) => {
   res.send(dms);
 });
 
-chat.get('/existingDms', async (req, res) => {
+chat.get('/dmPreviews', async (req, res) => {
   const { senderId } = req.query;
   const senderNum: number = Number(senderId);
   // this query grabs the most recent sent and received msg from every convo user is a part of
   // the most recent msg comes first
-  const existingDms = await Message.findMany({
+  const dmPreviews = await Message.findMany({
     where: { OR: [{ senderId: senderNum }, { recipientId: senderNum }] },
     orderBy: [{ id: 'desc' }],
     distinct: ['senderId', 'recipientId'],
@@ -63,7 +63,7 @@ chat.get('/existingDms', async (req, res) => {
     },
   });
 
-  res.send(existingDms);
+  res.send(dmPreviews);
 });
 
 export = chat;

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -45,4 +45,27 @@ chat.get('/dms', async (req, res) => {
   res.send(dms);
 });
 
+chat.get('/existingDms', async (req, res) => {
+  console.log(req);
+  // only need user id
+  const { senderId } = req.query;
+  const senderNum: number = Number(senderId);
+  // find all users that currently have dms with user
+  // select name, id, and most recent message
+  // figure out how to only select the most recent msg from current chats
+  // maybe try to first get only the ids - then a second that only grabs the first from those ids
+  const existingDms = await Message.findMany({
+    where: { OR: [{ senderId: senderNum }, { recipientId: senderNum }] },
+    select: {
+      senderId: true,
+      recipientId: true,
+      msg: true,
+      sender: { select: { name: true, preferredName: true } },
+      recipient: { select: { name: true, preferredName: true } },
+    },
+  });
+
+  res.send(existingDms);
+});
+
 export = chat;

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -46,12 +46,12 @@ chat.get('/dms', async (req, res) => {
 });
 
 chat.get('/dmPreviews', async (req, res) => {
-  const { senderId } = req.query;
-  const senderNum: number = Number(senderId);
+  const { userId } = req.query;
+  const userNum: number = Number(userId);
   // this query grabs the most recent sent and received msg from every convo user is a part of
   // the most recent msg comes first
   const dmPreviews = await Message.findMany({
-    where: { OR: [{ senderId: senderNum }, { recipientId: senderNum }] },
+    where: { OR: [{ senderId: userNum }, { recipientId: userNum }] },
     orderBy: [{ id: 'desc' }],
     distinct: ['senderId', 'recipientId'],
     select: {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -21,6 +21,7 @@ import { Message, Dm, DmPreview } from '../types/chat';
 
 import ChatInput from './ChatComponents/ChatInput';
 import UserSearchInput from './ChatComponents/UserSearchInput';
+import FoundUsers from './ChatComponents/FoundUsers';
 import DmPreviews from './ChatComponents/DmPreviews';
 
 const socket: Socket = io();
@@ -267,11 +268,12 @@ function Chat() {
             onSearch={onSearch}
             onPress={onPress}
           />
-          {foundUsers.map((foundUser) => (
+          {/* {foundUsers.map((foundUser) => (
             <Text onClick={userSelect} key={foundUser.googleId} id={`${foundUser.id}`}>
               {foundUser.preferredName || foundUser.name}
             </Text>
-          ))}
+          ))} */}
+          <FoundUsers foundUsers={foundUsers} userSelect={userSelect} />
           <DmPreviews dmPreviews={dmPreviews} select={dmPreviewSelect} />
         </>
       )}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -55,30 +55,50 @@ function Chat() {
 
   useEffect(bottomScroll, [messages]);
 
+  const getDmPreviews: (userId: number) => void = (userId) => {
+    axios
+      .get('/chat/dmPreviews', { params: { userId } })
+      .then((dmPreviewsResponse: { data: DmPreview[] }) => {
+        const reducedPreviews: DmPreview[] = dmPreviewsResponse.data.reduce((acc, curDm) => {
+          if (!acc.length) {
+            acc.push(curDm);
+            return acc;
+          }
+          for (let i = acc.length - 1; i >= 0; i -= 1) {
+            if (acc[i].senderId === curDm.recipientId && acc[i].recipientId === curDm.senderId) {
+              return acc;
+            }
+          }
+          acc.push(curDm);
+          return acc;
+        }, [] as DmPreview[]);
+        setDmPreviews(reducedPreviews);
+      });
+  };
+
   useEffect(() => {
     axios.get('/user').then((userResponse: { data: User }) => {
       setUser(userResponse.data);
-      axios
-        .get('/chat/dmPreviews', { params: { userId: userResponse.data.id } })
-        .then((dmPreviewsResponse: { data: DmPreview[] }) => {
-          const reducedPreviews: DmPreview[] = dmPreviewsResponse.data.reduce((acc, curDm) => {
-            if (!acc.length) {
-              acc.push(curDm);
-              return acc;
-            }
-            for (let i = acc.length - 1; i >= 0; i -= 1) {
-              if (
-                acc[i].senderId === curDm.recipientId &&
-                acc[i].recipientId === curDm.senderId
-              ) {
-                return acc;
-              }
-            }
-            acc.push(curDm);
-            return acc;
-          }, [] as DmPreview[]);
-          setDmPreviews(reducedPreviews);
-        });
+      getDmPreviews(userResponse.data.id);
+      // axios
+      //   .get('/chat/dmPreviews', { params: { userId: userResponse.data.id } })
+      //   .then((dmPreviewsResponse: { data: DmPreview[] }) => {
+      //     const reducedPreviews: DmPreview[] = dmPreviewsResponse.data.reduce((acc, curDm) => {
+      //       if (!acc.length) {
+      //         acc.push(curDm);
+      //         return acc;
+      //       }
+      //       for (let i = acc.length - 1; i >= 0; i -= 1) {
+      //         if (acc[i].senderId === curDm.recipientId &&
+      // acc[i].recipientId === curDm.senderId) {
+      //           return acc;
+      //         }
+      //       }
+      //       acc.push(curDm);
+      //       return acc;
+      //     }, [] as DmPreview[]);
+      //     setDmPreviews(reducedPreviews);
+      //   });
     });
   }, [setUser, setDmPreviews]);
 
@@ -89,6 +109,7 @@ function Chat() {
         .then((dmResponse) => setDms(dmResponse.data))
         .catch((err) => console.error('Failed finding existing messages: ', err));
       setFoundUsers([] as User[]);
+      // setDmPreviews([] as DmPreview[]);
     }
   }, [selectedUser.id, user.id]);
 
@@ -208,6 +229,7 @@ function Chat() {
   const backToPreview = () => {
     setSelectedUser({} as User);
     setDms([] as Dm[]);
+    getDmPreviews(user.id);
   };
 
   const onMouseHover = (

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -79,8 +79,32 @@ function Chat() {
   useEffect(bottomScroll, [messages]);
 
   useEffect(() => {
-    axios.get('/user').then((response) => setUser(response.data));
-  });
+    axios.get('/user').then((userResponse: { data: User }) => {
+      setUser(userResponse.data);
+      axios
+        .get('/chat/dmPreviews', { params: { userId: userResponse.data.id } })
+        .then((dmPreviewsResponse: { data: DmPreview[] }) => {
+          const reducedPreviews: DmPreview[] = dmPreviewsResponse.data.reduce((acc, curDm) => {
+            if (!acc.length) {
+              acc.push(curDm);
+              return acc;
+            }
+            if (
+              acc[acc.length - 1].senderId === curDm.recipientId &&
+              acc[acc.length - 1].recipientId === curDm.senderId
+            ) {
+              return acc;
+            }
+            acc.push(curDm);
+            return acc;
+          }, [] as DmPreview[]);
+          setDmPreviews(reducedPreviews);
+          // setDmPreviews(dmPreviewsResponse.data);
+          console.log(dmPreviewsResponse.data);
+          console.log(reducedPreviews);
+        });
+    });
+  }, [setUser, setDmPreviews]);
 
   useEffect(() => {
     if (selectedUser.id) {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -66,11 +66,13 @@ function Chat() {
               acc.push(curDm);
               return acc;
             }
-            if (
-              acc[acc.length - 1].senderId === curDm.recipientId &&
-              acc[acc.length - 1].recipientId === curDm.senderId
-            ) {
-              return acc;
+            for (let i = acc.length - 1; i >= 0; i -= 1) {
+              if (
+                acc[i].senderId === curDm.recipientId &&
+                acc[i].recipientId === curDm.senderId
+              ) {
+                return acc;
+              }
             }
             acc.push(curDm);
             return acc;

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -36,8 +36,6 @@ function Chat() {
 
   const [foundUsers, setFoundUsers] = useState([] as User[]);
 
-  // const [tabIndex, setTabIndex] = useState(0);
-
   const [dm, setDm] = useState('');
 
   const [dms, setDms] = useState([] as Dm[]);
@@ -77,9 +75,6 @@ function Chat() {
             return acc;
           }, [] as DmPreview[]);
           setDmPreviews(reducedPreviews);
-          // setDmPreviews(dmPreviewsResponse.data);
-          // console.log(dmPreviewsResponse.data);
-          // console.log(reducedPreviews);
         });
     });
   }, [setUser, setDmPreviews]);
@@ -168,7 +163,6 @@ function Chat() {
       target: React.ButtonHTMLAttributes<HTMLButtonElement>;
     },
   ) => {
-    // setTabIndex(1);
     axios.get('/chat/user', { params: { id: e.target.id } }).then((userResponse) => {
       setSelectedUser(userResponse.data);
       const roomName: string =
@@ -185,11 +179,6 @@ function Chat() {
       target: React.ButtonHTMLAttributes<HTMLButtonElement>;
     },
   ) => {
-    // console.log(e.target.id);
-    // console.log(
-    //   Number(e.target.id.split('-')[0]) !== user.id,
-    //   Number(e.target.id.split('-')[1]) !== user.id,
-    // );
     const ids: string[] = e.target.id.split('-');
     const firstId: number = Number(ids[0]);
     const secondId: number = Number(ids[1]);
@@ -282,81 +271,8 @@ function Chat() {
           />
         </Box>
       ) : (
-        // <div>{dms[0].msg}</div>
         <DmPreviews dmPreviews={dmPreviews} select={dmPreviewSelect} />
       )}
-      {/* <Tabs index={tabIndex} onChange={(index) => setTabIndex(index)}>
-        <TabList>
-          <Tab>Main</Tab>
-          <Tab>DMs</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>
-            <Center>
-              <Text>
-                This is currently a chat with between you and anyone else logged on the chat!
-              </Text>
-            </Center>
-            <Box overflowY="auto" maxHeight="70vh" marginBottom="10px" marginTop="15px">
-              <Stack divider={<StackDivider />} margin="8px">
-                {messages.map((msg, index) => (
-                  <Text
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={`${msg.clientOffset}-${index}`}
-                    borderRadius="10px"
-                    background={msg.clientOffset === socket.id ? 'blue.600' : otherUserBG}
-                    p="10px"
-                    color={msg.clientOffset === socket.id ? 'white' : otherUserColor}
-                    textAlign={msg.clientOffset === socket.id ? 'right' : 'left'}
-                    marginLeft={msg.clientOffset === socket.id ? 'auto' : 0}
-                    width="fit-content"
-                  >
-                    {msg.msg}
-                  </Text>
-                ))}
-              </Stack>
-              <ChatInput
-                messagesEndRef={messagesEndRef}
-                message={message}
-                onChange={onChange}
-                onSend={onSend}
-                onPress={onPress}
-                id="chat"
-              />
-            </Box>
-          </TabPanel>
-          <TabPanel>
-            <Center>
-              <Text>{selectedUser.preferredName || selectedUser.name}</Text>
-            </Center>
-            <Stack divider={<StackDivider />} margin="8px">
-              {dms.map((msg, index) => (
-                <Text
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={`${msg.senderId}-${index}`}
-                  borderRadius="10px"
-                  background={msg.senderId === user.id ? 'blue.600' : otherUserBG}
-                  p="10px"
-                  color={msg.senderId === user.id ? 'white' : otherUserColor}
-                  textAlign={msg.senderId === user.id ? 'right' : 'left'}
-                  marginLeft={msg.senderId === user.id ? 'auto' : 0}
-                  width="fit-content"
-                >
-                  {msg.msg}
-                </Text>
-              ))}
-            </Stack>
-            <ChatInput
-              messagesEndRef={messagesEndRef}
-              message={dm}
-              onChange={onChange}
-              onSend={onSendDm}
-              onPress={onPress}
-              id="dm"
-            />
-          </TabPanel>
-        </TabPanels>
-      </Tabs> */}
     </Container>
   );
 }

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -18,36 +18,15 @@ import {
 } from '@chakra-ui/react';
 
 import { User } from '@prisma/client';
+import { Message, Dm, DmPreview } from '../types/chat';
 
 import ChatInput from './ChatComponents/ChatInput';
 import UserSearchInput from './ChatComponents/UserSearchInput';
+import DmPreviews from './ChatComponents/DmPreviews';
 
 const socket: Socket = io();
 
 function Chat() {
-  interface Message {
-    msg: string;
-    clientOffset: string;
-  }
-  type Dm = {
-    msg: string;
-    senderId: number;
-    recipientId: number;
-  };
-
-  type DmPreviewUser = {
-    name: string;
-    preferredName: string | null;
-  };
-
-  type DmPreview = {
-    senderId: number;
-    recipientId: number;
-    msg: string;
-    sender: DmPreviewUser;
-    recipient: DmPreviewUser;
-  };
-
   const [user, setUser] = useState({} as User);
 
   const [message, setMessage] = useState('');
@@ -224,6 +203,7 @@ function Chat() {
           {foundUser.preferredName || foundUser.name}
         </Text>
       ))}
+      <DmPreviews dmPreviews={dmPreviews} />
       <Tabs index={tabIndex} onChange={(index) => setTabIndex(index)}>
         <TabList>
           <Tab>Main</Tab>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -86,6 +86,7 @@ function Chat() {
         .get('/chat/dms', { params: { senderId: user.id, recipientId: selectedUser.id } })
         .then((dmResponse) => setDms(dmResponse.data))
         .catch((err) => console.error('Failed finding existing messages: ', err));
+      setFoundUsers([] as User[]);
     }
   }, [selectedUser.id, user.id]);
 

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -212,6 +212,11 @@ function Chat() {
     });
   };
 
+  const backToPreview = () => {
+    setSelectedUser({} as User);
+    setDms([] as Dm[]);
+  };
+
   const color = useColorModeValue('blue.600', 'blue.200');
 
   const otherUserBG = useColorModeValue('lavender', 'purple.700');
@@ -239,7 +244,7 @@ function Chat() {
           <Grid mt=".5rem" templateColumns="repeat(5, 1fr)" gap={1}>
             <GridItem>
               <Button p="0" minW="30px" height="30px">
-                <ArrowBackIcon width="20px" height="20px" />
+                <ArrowBackIcon onClick={backToPreview} width="20px" height="20px" />
               </Button>
             </GridItem>
             <GridItem colSpan={1} />

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -284,11 +284,6 @@ function Chat() {
             onSearch={onSearch}
             onPress={onPress}
           />
-          {/* {foundUsers.map((foundUser) => (
-            <Text onClick={userSelect} key={foundUser.googleId} id={`${foundUser.id}`}>
-              {foundUser.preferredName || foundUser.name}
-            </Text>
-          ))} */}
           <FoundUsers
             foundUsers={foundUsers}
             userSelect={userSelect}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -10,12 +10,10 @@ import {
   useColorModeValue,
   Text,
   Box,
-  // Tabs,
-  // TabList,
-  // Tab,
-  // TabPanels,
-  // TabPanel,
+  Grid,
+  GridItem,
 } from '@chakra-ui/react';
+import { ArrowBackIcon } from '@chakra-ui/icons';
 
 import { User } from '@prisma/client';
 import { Message, Dm, DmPreview } from '../types/chat';
@@ -237,9 +235,18 @@ function Chat() {
       ))}
       {dms.length ? (
         <Box>
-          <Center>
-            <Text>{selectedUser.preferredName || selectedUser.name}</Text>
-          </Center>
+          <Grid templateColumns="repeat(5, 1fr)" gap={1}>
+            <GridItem>
+              <ArrowBackIcon />
+            </GridItem>
+            <GridItem colSpan={1} />
+            <GridItem>
+              <Center>
+                <Text>{selectedUser.preferredName || selectedUser.name}</Text>
+              </Center>
+            </GridItem>
+            <GridItem colSpan={2} />
+          </Grid>
           <Stack divider={<StackDivider />} margin="8px">
             {dms.map((msg, index) => (
               <Text

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -78,8 +78,8 @@ function Chat() {
           }, [] as DmPreview[]);
           setDmPreviews(reducedPreviews);
           // setDmPreviews(dmPreviewsResponse.data);
-          console.log(dmPreviewsResponse.data);
-          console.log(reducedPreviews);
+          // console.log(dmPreviewsResponse.data);
+          // console.log(reducedPreviews);
         });
     });
   }, [setUser, setDmPreviews]);
@@ -185,11 +185,11 @@ function Chat() {
       target: React.ButtonHTMLAttributes<HTMLButtonElement>;
     },
   ) => {
-    console.log(e.target.id);
-    console.log(
-      Number(e.target.id.split('-')[0]) !== user.id,
-      Number(e.target.id.split('-')[1]) !== user.id,
-    );
+    // console.log(e.target.id);
+    // console.log(
+    //   Number(e.target.id.split('-')[0]) !== user.id,
+    //   Number(e.target.id.split('-')[1]) !== user.id,
+    // );
     const ids: string[] = e.target.id.split('-');
     const firstId: number = Number(ids[0]);
     const secondId: number = Number(ids[1]);

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -217,17 +217,6 @@ function Chat() {
       <Center>
         <Heading color={color}>Chat</Heading>
       </Center>
-      <UserSearchInput
-        userSearch={userSearch}
-        onChange={onChange}
-        onSearch={onSearch}
-        onPress={onPress}
-      />
-      {foundUsers.map((foundUser) => (
-        <Text onClick={userSelect} key={foundUser.googleId} id={`${foundUser.id}`}>
-          {foundUser.preferredName || foundUser.name}
-        </Text>
-      ))}
       {dms.length ? (
         <Box>
           <Grid mt=".5rem" templateColumns="repeat(5, 1fr)" gap={1}>
@@ -271,7 +260,20 @@ function Chat() {
           />
         </Box>
       ) : (
-        <DmPreviews dmPreviews={dmPreviews} select={dmPreviewSelect} />
+        <>
+          <UserSearchInput
+            userSearch={userSearch}
+            onChange={onChange}
+            onSearch={onSearch}
+            onPress={onPress}
+          />
+          {foundUsers.map((foundUser) => (
+            <Text onClick={userSelect} key={foundUser.googleId} id={`${foundUser.id}`}>
+              {foundUser.preferredName || foundUser.name}
+            </Text>
+          ))}
+          <DmPreviews dmPreviews={dmPreviews} select={dmPreviewSelect} />
+        </>
       )}
     </Container>
   );

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -12,6 +12,7 @@ import {
   Box,
   Grid,
   GridItem,
+  Button,
 } from '@chakra-ui/react';
 import { ArrowBackIcon } from '@chakra-ui/icons';
 
@@ -235,9 +236,11 @@ function Chat() {
       ))}
       {dms.length ? (
         <Box>
-          <Grid templateColumns="repeat(5, 1fr)" gap={1}>
+          <Grid mt=".5rem" templateColumns="repeat(5, 1fr)" gap={1}>
             <GridItem>
-              <ArrowBackIcon />
+              <Button p="0" minW="30px" height="30px">
+                <ArrowBackIcon width="20px" height="20px" />
+              </Button>
             </GridItem>
             <GridItem colSpan={1} />
             <GridItem>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -207,6 +207,22 @@ function Chat() {
     setDms([] as Dm[]);
   };
 
+  const onMouseHover = (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    },
+  ) => {
+    e.target.style.textDecoration = 'underline';
+  };
+
+  const onMouseLeave = (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    },
+  ) => {
+    e.target.style.textDecoration = 'none';
+  };
+
   const color = useColorModeValue('blue.600', 'blue.200');
 
   const otherUserBG = useColorModeValue('lavender', 'purple.700');
@@ -273,8 +289,18 @@ function Chat() {
               {foundUser.preferredName || foundUser.name}
             </Text>
           ))} */}
-          <FoundUsers foundUsers={foundUsers} userSelect={userSelect} />
-          <DmPreviews dmPreviews={dmPreviews} select={dmPreviewSelect} />
+          <FoundUsers
+            foundUsers={foundUsers}
+            userSelect={userSelect}
+            onMouseHover={onMouseHover}
+            onMouseLeave={onMouseLeave}
+          />
+          <DmPreviews
+            dmPreviews={dmPreviews}
+            select={dmPreviewSelect}
+            onMouseHover={onMouseHover}
+            onMouseLeave={onMouseLeave}
+          />
         </>
       )}
     </Container>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -35,6 +35,19 @@ function Chat() {
     recipientId: number;
   };
 
+  type DmPreviewUser = {
+    name: string;
+    preferredName: string | null;
+  };
+
+  type DmPreview = {
+    senderId: number;
+    recipientId: number;
+    msg: string;
+    sender: DmPreviewUser;
+    recipient: DmPreviewUser;
+  };
+
   const [user, setUser] = useState({} as User);
 
   const [message, setMessage] = useState('');
@@ -54,6 +67,8 @@ function Chat() {
   const [room, setRoom] = useState('');
 
   const [selectedUser, setSelectedUser] = useState({} as User);
+
+  const [dmPreviews, setDmPreviews] = useState([] as DmPreview[]);
 
   const messagesEndRef = useRef(null);
 

--- a/src/components/ChatComponents/DmPreviews.tsx
+++ b/src/components/ChatComponents/DmPreviews.tsx
@@ -5,9 +5,21 @@ import { DmPreview } from '../../types/chat';
 function DmPreviews({
   dmPreviews,
   select,
+  onMouseHover,
+  onMouseLeave,
 }: {
   dmPreviews: DmPreview[];
   select: (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    },
+  ) => void;
+  onMouseHover: (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    },
+  ) => void;
+  onMouseLeave: (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
       target: React.ButtonHTMLAttributes<HTMLButtonElement>;
     },
@@ -25,21 +37,21 @@ function DmPreviews({
     return shortMsg;
   };
 
-  const onMouseHover = (
-    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
-      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
-    },
-  ) => {
-    e.target.style.textDecoration = 'underline';
-  };
+  // const onMouseHover = (
+  //   e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+  //     target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+  //   },
+  // ) => {
+  //   e.target.style.textDecoration = 'underline';
+  // };
 
-  const onMouseLeave = (
-    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
-      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
-    },
-  ) => {
-    e.target.style.textDecoration = 'none';
-  };
+  // const onMouseLeave = (
+  //   e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+  //     target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+  //   },
+  // ) => {
+  //   e.target.style.textDecoration = 'none';
+  // };
 
   return (
     <VStack

--- a/src/components/ChatComponents/DmPreviews.tsx
+++ b/src/components/ChatComponents/DmPreviews.tsx
@@ -13,11 +13,15 @@ function DmPreviews({ dmPreviews }: { dmPreviews: DmPreview[] }) {
     return shortMsg;
   };
 
-  const onMouseHover = (e) => {
+  const onMouseHover = (e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+    target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+  }) => {
     e.target.style.textDecoration = 'underline';
   };
 
-  const onMouseLeave = (e) => {
+  const onMouseLeave = (e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+    target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+  }) => {
     e.target.style.textDecoration = 'none';
   };
 

--- a/src/components/ChatComponents/DmPreviews.tsx
+++ b/src/components/ChatComponents/DmPreviews.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Box, StackDivider, Text, VStack } from '@chakra-ui/react';
+import { DmPreview } from '../../types/chat';
+
+function DmPreviews({ dmPreviews }: { dmPreviews: DmPreview[] }) {
+  const shortenMsg: (msg: string) => string = (msg) => {
+    let shortMsg: string;
+    if (msg.length < 60) {
+      shortMsg = msg;
+    } else {
+      shortMsg = `${msg.substring(0, msg.substring(0, 50).lastIndexOf(' '))}...`;
+    }
+    return shortMsg;
+  };
+
+  const onMouseHover = (e) => {
+    e.target.style.textDecoration = 'underline';
+  };
+
+  const onMouseLeave = (e) => {
+    e.target.style.textDecoration = 'none';
+  };
+
+  return (
+    <VStack divider={<StackDivider />} backgroundColor="whitesmoke" alignItems="start" borderRadius=".4rem" mt=".4rem" p=".5rem">
+      {dmPreviews.map((dm) => (
+        <Box key={`${dm.senderId}-${dm.recipientId}`}>
+          <Text id={`text-${dm.senderId}-${dm.recipientId}`} onMouseEnter={onMouseHover} onMouseLeave={onMouseLeave}>{`${dm.recipient.preferredName || dm.recipient.name}: ${shortenMsg(dm.msg)}`}</Text>
+        </Box>
+      ))}
+    </VStack>
+  );
+}
+
+export default DmPreviews;

--- a/src/components/ChatComponents/DmPreviews.tsx
+++ b/src/components/ChatComponents/DmPreviews.tsx
@@ -37,22 +37,6 @@ function DmPreviews({
     return shortMsg;
   };
 
-  // const onMouseHover = (
-  //   e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
-  //     target: React.ButtonHTMLAttributes<HTMLButtonElement>;
-  //   },
-  // ) => {
-  //   e.target.style.textDecoration = 'underline';
-  // };
-
-  // const onMouseLeave = (
-  //   e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
-  //     target: React.ButtonHTMLAttributes<HTMLButtonElement>;
-  //   },
-  // ) => {
-  //   e.target.style.textDecoration = 'none';
-  // };
-
   return (
     <VStack
       divider={<StackDivider />}

--- a/src/components/ChatComponents/DmPreviews.tsx
+++ b/src/components/ChatComponents/DmPreviews.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Box, StackDivider, Text, VStack } from '@chakra-ui/react';
+import { Box, StackDivider, Text, VStack, useColorModeValue } from '@chakra-ui/react';
 import { DmPreview } from '../../types/chat';
 
 function DmPreviews({ dmPreviews }: { dmPreviews: DmPreview[] }) {
+  const bgClr = useColorModeValue('whitesmoke', 'default');
+
   const shortenMsg: (msg: string) => string = (msg) => {
     let shortMsg: string;
     if (msg.length < 60) {
@@ -26,7 +28,7 @@ function DmPreviews({ dmPreviews }: { dmPreviews: DmPreview[] }) {
   };
 
   return (
-    <VStack divider={<StackDivider />} backgroundColor="whitesmoke" alignItems="start" borderRadius=".4rem" mt=".4rem" p=".5rem">
+    <VStack divider={<StackDivider />} backgroundColor={bgClr} alignItems="start" borderRadius=".4rem" mt=".4rem" p=".5rem">
       {dmPreviews.map((dm) => (
         <Box key={`${dm.senderId}-${dm.recipientId}`}>
           <Text id={`text-${dm.senderId}-${dm.recipientId}`} onMouseEnter={onMouseHover} onMouseLeave={onMouseLeave}>{`${dm.recipient.preferredName || dm.recipient.name}: ${shortenMsg(dm.msg)}`}</Text>

--- a/src/components/ChatComponents/DmPreviews.tsx
+++ b/src/components/ChatComponents/DmPreviews.tsx
@@ -2,7 +2,17 @@ import React from 'react';
 import { Box, StackDivider, Text, VStack, useColorModeValue } from '@chakra-ui/react';
 import { DmPreview } from '../../types/chat';
 
-function DmPreviews({ dmPreviews }: { dmPreviews: DmPreview[] }) {
+function DmPreviews({
+  dmPreviews,
+  select,
+}: {
+  dmPreviews: DmPreview[];
+  select: (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    },
+  ) => void;
+}) {
   const bgClr = useColorModeValue('whitesmoke', 'default');
 
   const shortenMsg: (msg: string) => string = (msg) => {
@@ -15,23 +25,41 @@ function DmPreviews({ dmPreviews }: { dmPreviews: DmPreview[] }) {
     return shortMsg;
   };
 
-  const onMouseHover = (e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
-    target: React.ButtonHTMLAttributes<HTMLButtonElement>;
-  }) => {
+  const onMouseHover = (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    },
+  ) => {
     e.target.style.textDecoration = 'underline';
   };
 
-  const onMouseLeave = (e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
-    target: React.ButtonHTMLAttributes<HTMLButtonElement>;
-  }) => {
+  const onMouseLeave = (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    },
+  ) => {
     e.target.style.textDecoration = 'none';
   };
 
   return (
-    <VStack divider={<StackDivider />} backgroundColor={bgClr} alignItems="start" borderRadius=".4rem" mt=".4rem" p=".5rem">
+    <VStack
+      divider={<StackDivider />}
+      backgroundColor={bgClr}
+      alignItems="start"
+      borderRadius=".4rem"
+      mt=".4rem"
+      p=".5rem"
+    >
       {dmPreviews.map((dm) => (
         <Box key={`${dm.senderId}-${dm.recipientId}`}>
-          <Text id={`text-${dm.senderId}-${dm.recipientId}`} onMouseEnter={onMouseHover} onMouseLeave={onMouseLeave}>{`${dm.recipient.preferredName || dm.recipient.name}: ${shortenMsg(dm.msg)}`}</Text>
+          <Text
+            id={`${dm.senderId}-${dm.recipientId}`}
+            onMouseEnter={onMouseHover}
+            onMouseLeave={onMouseLeave}
+            onClick={select}
+          >
+            {`${dm.recipient.preferredName || dm.recipient.name}: ${shortenMsg(dm.msg)}`}
+          </Text>
         </Box>
       ))}
     </VStack>

--- a/src/components/ChatComponents/FoundUsers.tsx
+++ b/src/components/ChatComponents/FoundUsers.tsx
@@ -5,9 +5,21 @@ import { User } from '@prisma/client';
 function FoundUsers({
   foundUsers,
   userSelect,
+  onMouseHover,
+  onMouseLeave,
 }: {
   foundUsers: User[];
   userSelect: (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    },
+  ) => void;
+  onMouseHover: (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    },
+  ) => void;
+  onMouseLeave: (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
       target: React.ButtonHTMLAttributes<HTMLButtonElement>;
     },
@@ -18,7 +30,7 @@ function FoundUsers({
   return foundUsers.length ? (
     <VStack divider={<StackDivider />} backgroundColor={bgClr} alignItems="start" p=".5rem">
       {foundUsers.map((foundUser) => (
-        <Text onClick={userSelect} key={foundUser.googleId} id={`${foundUser.id}`}>
+        <Text onClick={userSelect} onMouseEnter={onMouseHover} onMouseLeave={onMouseLeave} key={foundUser.googleId} id={`${foundUser.id}`}>
           {foundUser.preferredName || foundUser.name}
         </Text>
       ))}

--- a/src/components/ChatComponents/FoundUsers.tsx
+++ b/src/components/ChatComponents/FoundUsers.tsx
@@ -1,0 +1,29 @@
+import { StackDivider, VStack, useColorModeValue, Text } from '@chakra-ui/react';
+import React from 'react';
+import { User } from '@prisma/client';
+
+function FoundUsers({
+  foundUsers,
+  userSelect,
+}: {
+  foundUsers: User[];
+  userSelect: (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent> & {
+      target: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    },
+  ) => void;
+}) {
+  const bgClr = useColorModeValue('whitesmoke', 'default');
+
+  return foundUsers.length ? (
+    <VStack divider={<StackDivider />} backgroundColor={bgClr} alignItems="start" p=".5rem">
+      {foundUsers.map((foundUser) => (
+        <Text onClick={userSelect} key={foundUser.googleId} id={`${foundUser.id}`}>
+          {foundUser.preferredName || foundUser.name}
+        </Text>
+      ))}
+    </VStack>
+  ) : null;
+}
+
+export default FoundUsers;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -20,6 +20,7 @@ import {
   useColorMode,
   useColorModeValue,
   Image,
+  Text,
 } from '@chakra-ui/react';
 import { SunIcon, MoonIcon } from '@chakra-ui/icons';
 import Logout from './Logout';
@@ -35,13 +36,15 @@ function Navbar() {
   const text = useColorModeValue('blue.600', 'whitesmoke');
 
   return (
-    <Container className="navContainer" width="100%" maxW="inherit" bg={bg} h="4.5rem">
-      <Flex className="navFlex" alignItems="center" gap="2" minWidth="max-content">
+    <Container className="navContainer" width="100%" maxW="inherit" bg={bg} h="3.25rem">
+      <Flex className="navFlex" alignItems="center" gap="2" minWidth="max-content" maxH="3.25rem">
         <Box className="GriefBuddyBox">
           <Center>
             <Heading as="h1" size="xl" color={textHeading}>
               {useLocation().pathname === '/' ? (
-                'GriefBuddy'
+                <Text fontSize="2.5rem">
+                  GriefBuddy
+                </Text>
               ) : (
                 <Link to="/home" style={{ fontSize: '2.5rem' }}>
                   GriefBuddy

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,23 @@
+export interface Message {
+  msg: string;
+  clientOffset: string;
+}
+
+export type Dm = {
+  msg: string;
+  senderId: number;
+  recipientId: number;
+};
+
+type DmPreviewUser = {
+  name: string;
+  preferredName: string | null;
+};
+
+export type DmPreview = {
+  senderId: number;
+  recipientId: number;
+  msg: string;
+  sender: DmPreviewUser;
+  recipient: DmPreviewUser;
+};


### PR DESCRIPTION
- Chat
  - Remove global chat
  - open to see most recent message of all convos; long messages are shortened in preview; shows users preferred name if exists, otherwise google display name <img width="361" alt="Screenshot 2024-06-23 at 3 50 14 PM" src="https://github.com/The-KPCP-Hotel/griefbuddy/assets/63323084/98329223-2640-4d6b-a916-a66d989ff631">
  - can search for other users <img width="622" alt="Screenshot 2024-06-23 at 5 23 53 PM" src="https://github.com/The-KPCP-Hotel/griefbuddy/assets/63323084/e73998ac-1c50-4aab-933e-3b9d50a8781f">
  - previews and found users are underlined when hovering <img width="627" alt="Screenshot 2024-06-23 at 5 25 11 PM" src="https://github.com/The-KPCP-Hotel/griefbuddy/assets/63323084/63818a24-6c8d-4539-b452-e5e7de64db26">
  - click of preview or found user opens chat; can click back arrow to return to refreshed preview and search <img width="642" alt="Screenshot 2024-06-23 at 5 27 59 PM" src="https://github.com/The-KPCP-Hotel/griefbuddy/assets/63323084/7014e7db-4393-4270-bb84-c06515b12ec7">
- Nav bar
  - GriefBuddy has same font size in login vs rest of site 
  - Shrunk nav bar height <img width="508" alt="Screenshot 2024-06-23 at 5 29 14 PM" src="https://github.com/The-KPCP-Hotel/griefbuddy/assets/63323084/47b3a646-5f8f-4334-8bc4-1e03cbc32eac">
